### PR TITLE
feat(unify-eslint-config): Unify eslint config across monorepo

### DIFF
--- a/.eslintrc-ts.js
+++ b/.eslintrc-ts.js
@@ -1,0 +1,42 @@
+module.exports = {
+  extends: [
+    '.eslintrc.js',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking'
+  ],
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly',
+  },
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    'react',
+    'import',
+    '@typescript-eslint',
+  ],
+  rules: {
+    'react/jsx-filename-extension': [1, { 'extensions': ['.tsx'] }],
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never'
+      }
+    ],
+    'import/no-unresolved': 'error'
+  },
+  'settings': {
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts', '.tsx']
+    },
+    'import/resolver': {
+      'typescript': {
+        'alwaysTryTypes': true // always try to resolve types under `<roo/>@types` directory even it doesn't contain any source code, like `@types/unist`
+      },
+    }
+  }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: [
+    'airbnb',
+    'prettier',
+    'plugin:cypress/recommended',
+    'plugin:react/recommended',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "devDependencies": {
     "husky": "^4.2.3"
   },
+  "scripts": {
+    "lint": "yarn workspaces run lint"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "yarn workspaces run pre-commit"

--- a/site/.eslintrc.js
+++ b/site/.eslintrc.js
@@ -1,13 +1,15 @@
 module.exports = {
-  extends: ['airbnb', 'prettier', 'plugin:cypress/recommended'],
-  rules: {
-    'react/jsx-filename-extension': 'off',
-    'react/require-default-props': 'off',
-  },
+  extends: ['../.eslintrc.js'],
   parser: 'babel-eslint',
   env: {
     browser: true,
     node: true,
     jest: true,
+  },
+  rules: {
+    'react/jsx-filename-extension': 'off',
+    'react/require-default-props': 'off',
+    // TODO: Off while we get started
+    'no-unused-vars': 'off',
   },
 };

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -16,8 +16,8 @@ const IndexPage = () => (
     <About />
     <Resources />
     <Team />
-    {/*<Projects />*/}
-    {/*<Writing />*/}
+    {/* <Projects /> */}
+    {/* <Writing /> */}
     <Footer />
   </Layout>
 );

--- a/site/src/sections/Landing.js
+++ b/site/src/sections/Landing.js
@@ -79,24 +79,24 @@ const LandingPage = () => (
               {name}
             </Heading>
 
-            {/*<Heading*/}
-            {/*  as="h2"*/}
-            {/*  color="primary"*/}
-            {/*  fontSize={[4, 5, 6]}*/}
-            {/*  mb={[3, 5]}*/}
-            {/*  textAlign="center"*/}
-            {/*  style={centerHorizontally}*/}
-            {/*>*/}
-            {/*  <TextLoop interval={5000}>*/}
-            {/*    {roles*/}
-            {/*      .sort(() => deterministicBehaviour || Math.random() - 0.5)*/}
-            {/*      .map(text => (*/}
-            {/*        <Text width={[300, 500]} key={text}>*/}
-            {/*          {text}*/}
-            {/*        </Text>*/}
-            {/*      ))}*/}
-            {/*  </TextLoop>*/}
-            {/*</Heading>*/}
+            {/* <Heading */}
+            {/*  as="h2" */}
+            {/*  color="primary" */}
+            {/*  fontSize={[4, 5, 6]} */}
+            {/*  mb={[3, 5]} */}
+            {/*  textAlign="center" */}
+            {/*  style={centerHorizontally} */}
+            {/* > */}
+            {/*  <TextLoop interval={5000}> */}
+            {/*    {roles */}
+            {/*      .sort(() => deterministicBehaviour || Math.random() - 0.5) */}
+            {/*      .map(text => ( */}
+            {/*        <Text width={[300, 500]} key={text}> */}
+            {/*          {text} */}
+            {/*        </Text> */}
+            {/*      ))} */}
+            {/*  </TextLoop> */}
+            {/* </Heading> */}
 
             <Flex alignItems="center" justifyContent="center" flexWrap="wrap">
               {socialLinks.map(({ id, ...rest }) => (

--- a/web-client/.eslintrc.js
+++ b/web-client/.eslintrc.js
@@ -1,20 +1,7 @@
 module.exports = {
-  env: {
-    browser: true,
-    es6: true,
-  },
   extends: [
-    'plugin:react/recommended',
-    'airbnb',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking'
+    '../.eslintrc-ts.js',
   ],
-  globals: {
-    Atomics: 'readonly',
-    SharedArrayBuffer: 'readonly',
-  },
-  parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json',
     ecmaFeatures: {
@@ -23,33 +10,8 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: [
-    'react',
-    'import',
-    '@typescript-eslint',
-  ],
-  rules: {
-    'react/jsx-filename-extension': [1, { 'extensions': ['.tsx'] }],
-    'import/extensions': [
-      'error',
-      'ignorePackages',
-      {
-        js: 'never',
-        jsx: 'never',
-        ts: 'never',
-        tsx: 'never'
-      }
-    ],
-    'import/no-unresolved': 'error'
+  env: {
+    browser: true,
+    es6: true,
   },
-  'settings': {
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx']
-    },
-    'import/resolver': {
-      'typescript': {
-        'alwaysTryTypes': true // always try to resolve types under `<roo/>@types` directory even it doesn't contain any source code, like `@types/unist`
-      },
-    }
-  }
 };


### PR DESCRIPTION
As we start introducing new sub-projects and sub-packages, we don't want to have completely independent / vastly-different configs for eslint... this PR unifies them into central "base" configs for js and ts, and then extends those.

I also ran `lint --fix` in `site`

We probably want to do the same thing for the prettier config